### PR TITLE
feat: add tag tabs for event list

### DIFF
--- a/app/events/EventsList.tsx
+++ b/app/events/EventsList.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+import type { EventMeta } from '@/lib/content';
+
+const TABS = [
+  { key: undefined, label: '전체' },
+  { key: 'kbjjf', label: 'KBJJF' },
+  { key: 'street', label: '스트릿 주짓수' },
+  { key: 'yaegers', label: '예거스' },
+];
+
+export default function EventsList({ events }: { events: EventMeta[] }) {
+  const searchParams = useSearchParams();
+  const tag = searchParams.get('tag') || undefined;
+  const filtered = tag ? events.filter(e => e.tags?.includes(tag)) : events;
+  const items = filtered.slice(0, 10); // 최근 10개만
+
+  return (
+    <>
+      <div className="tabs">
+        {TABS.map(({ key, label }) => (
+          <Link
+            key={key ?? 'all'}
+            href={key ? `/events/?tag=${key}` : '/events/'}
+            className={`tab${key === tag ? ' active' : ''}`}
+          >
+            {label}
+          </Link>
+        ))}
+      </div>
+      <div className="grid">
+        {items.map(e => (
+          <div key={e.slug} className="card">
+            <h3 style={{ margin: '8px 0' }}>
+              <Link href={`/events/${e.slug}/`}>{e.title}</Link>
+            </h3>
+            <div className="small">
+              {new Date(e.date).toLocaleDateString('ko-KR')}
+              {e.city ? ` · ${e.city}` : ''}{e.venue ? ` · ${e.venue}` : ''}
+            </div>
+            <div style={{ marginTop: 8 }}>{e.excerpt}</div>
+            <div style={{ marginTop: 8 }}>
+              {e.tags?.map(t => (
+                <span key={t} className="badge">
+                  {t}
+                </span>
+              ))}
+            </div>
+            {e.registrationUrl ? (
+              <div style={{ marginTop: 8 }}>
+                <a href={e.registrationUrl} target="_blank">
+                  접수 링크
+                </a>
+              </div>
+            ) : null}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -1,33 +1,15 @@
-import Link from 'next/link';
+import { Suspense } from 'react';
 import { getAllEventsMeta } from '@/lib/content';
+import EventsList from './EventsList';
 
-export default function HomePage() {
-  const events = getAllEventsMeta().slice(0, 10); // 최근 10개만
+export default function EventsPage() {
+  const events = getAllEventsMeta();
   return (
     <div>
       <h1>주짓수 대회 일정</h1>
-      <div className="grid">
-        {events.map(e => (
-          <div key={e.slug} className="card">
-            <h3 style={{ margin: '8px 0' }}>
-              <Link href={`/events/${e.slug}/`}>{e.title}</Link>
-            </h3>
-            <div className="small">
-              {new Date(e.date).toLocaleDateString('ko-KR')}
-              {e.city ? ` · ${e.city}` : ''}{e.venue ? ` · ${e.venue}` : ''}
-            </div>
-            <div style={{ marginTop: 8 }}>{e.excerpt}</div>
-            <div style={{ marginTop: 8 }}>
-              {e.tags?.map(t => <span key={t} className="badge">{t}</span>)}
-            </div>
-            {e.registrationUrl ? (
-              <div style={{ marginTop: 8 }}>
-                <a href={e.registrationUrl} target="_blank">접수 링크</a>
-              </div>
-            ) : null}
-          </div>
-        ))}
-      </div>
+      <Suspense>
+        <EventsList events={events} />
+      </Suspense>
     </div>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -17,3 +17,7 @@ img { max-width: 100%; height: auto; display: block; }
 .card { border: 1px solid #eee; border-radius: 8px; padding: 16px; background: #fff; }
 .badge { display: inline-block; padding: 2px 8px; font-size: 12px; border: 1px solid #ddd; border-radius: 999px; margin-right: 6px; color: #444; }
 .small { color: #666; font-size: 14px; }
+
+.tabs { display: flex; gap: 8px; margin-bottom: 16px; }
+.tab { padding: 6px 12px; border: 1px solid #ddd; border-radius: 999px; font-size: 14px; }
+.tab.active { background: #111; color: #fff; border-color: #111; }


### PR DESCRIPTION
## Summary
- add client-side tab filtering for event list by organizer tags
- style new tab navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a688cb4080832aa47122d0320b5056