### PR TITLE
feat: add robots.txt and sitemap.xml

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+Sitemap: https://teamhyeok.github.io/team-jiujitsu/sitemap.xml
+

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://teamhyeok.github.io/team-jiujitsu/</loc>
+  </url>
+  <url>
+    <loc>https://teamhyeok.github.io/team-jiujitsu/events/</loc>
+  </url>
+  <url>
+    <loc>https://teamhyeok.github.io/team-jiujitsu/rules/</loc>
+  </url>
+</urlset>
+


### PR DESCRIPTION
## Summary
- allow crawling and expose sitemap
- add sitemap listing main pages

## Testing
- `npm run lint`
- `npm run build`
- `npx serve out` and `curl http://localhost:3000/robots.txt`
- `npx serve out` and `curl http://localhost:3000/sitemap.xml`


------
https://chatgpt.com/codex/tasks/task_e_68aadf299c94832aa9d26d649ee9209a