### PR TITLE
feat: add event JSON-LD and dynamic metadata

### DIFF
--- a/lib/content.ts
+++ b/lib/content.ts
@@ -24,6 +24,7 @@ export type EventMeta = BaseMeta & {
   city?: string;
   venue?: string;
   registrationUrl?: string;
+  organizer?: string;
 };
 
 function readDir(dir: string) {
@@ -73,6 +74,7 @@ export function getAllEventsMeta(): EventMeta[] {
       city: String(data.city || ''),
       venue: String(data.venue || ''),
       registrationUrl: String(data.registrationUrl || ''),
+      organizer: String(data.organizer || ''),
     } as EventMeta;
   });
   return items.sort((a, b) => (a.date > b.date ? -1 : 1));


### PR DESCRIPTION
## Summary
- add organizer field when loading event metadata
- inject Event JSON-LD and dynamic SEO metadata on event pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `curl -I 'https://search.google.com/test/rich-results?code=%3Cscript%20type%3D%22application/ld%2Bjson%22%3E%7B%22%40context%22%3A%20%22https%3A//schema.org%22%2C%20%22%40type%22%3A%20%22Event%22%2C%20%22name%22%3A%20%22%EC%8A%A4%ED%8A%B8%EB%A6%BF%20%EC%A3%BC%EC%A7%93%EC%88%98%2083%20%EB%8C%80%EA%B5%AC%20%EC%98%A4%ED%94%88%22%2C%20%22startDate%22%3A%20%222025-01-11%22%2C%20%22eventAttendanceMode%22%3A%20%22https%3A//schema.org/OfflineEventAttendanceMode%22%2C%20%22eventStatus%22%3A%20%22https%3A//schema.org/EventScheduled%22%2C%20%22organizer%22%3A%20%7B%22%40type%22%3A%20%22Organization%22%2C%20%22name%22%3A%20%22Street%20Jiujitsu%22%7D%2C%20%22location%22%3A%20%7B%22%40type%22%3A%20%22Place%22%2C%20%22name%22%3A%20%22%ED%85%8D%EC%8A%A4%ED%83%80%EC%9D%BC%EC%BD%A4%ED%94%8C%EB%A0%89%EC%8A%A4%22%2C%20%22address%22%3A%20%7B%22%40type%22%3A%20%22PostalAddress%22%2C%20%22addressLocality%22%3A%20%22%EB%8C%80%EA%B5%AC%22%2C%20%22addressCountry%22%3A%20%22KR%22%7D%7D%7D%3C/script%3E'` *(fails: 400 Bad Request)*

------
https://chatgpt.com/codex/tasks/task_e_68aadf310348832a90a1ccea05edf604