### PR TITLE
chore: update pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,33 +1,42 @@
-name: Deploy to GitHub Pages (static export)
-
+name: Deploy to GitHub Pages
 on:
-  push:
-    branches: [ "main" ]
+  push: { branches: [ main ] }
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency: pages
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20, cache: npm }
+      - run: corepack enable && corepack prepare npm@latest --activate
+      - run: npm ci
+      - run: npm run build                 # out/가 생성되어야 함 (Next.js는 output:'export')
+      - run: ls -la out && test -f out/index.html
 
-      - name: Setup Node
-        uses: actions/setup-node@v4
+      # ✅ 여기 추가
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
         with:
-          node-version: 20
-          cache: 'npm'
+          enablement: true                 # 첫 배포이거나 Pages가 비활성화돼 있으면 필요. 이후엔 생략 가능
 
-      - name: Install deps
-        run: npm ci
-
-      - name: Build (static export -> out/)
-        run: npm run build
-
-      - name: Deploy to gh-pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./out
+          path: ./out
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    environment: { name: github-pages }
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/nextjs.yml
+++ b/.github/workflows/nextjs.yml
@@ -53,9 +53,26 @@ jobs:
         with:
           node-version: "20"
           cache: ${{ steps.detect-package-manager.outputs.manager }}
+      - name: Ensure npm
+        run: |
+          corepack enable
+          corepack prepare npm@latest --activate
       - name: Setup Pages
+        if: ${{ secrets.PAGES_TOKEN != '' }}
         uses: actions/configure-pages@v5
         with:
+          token: ${{ secrets.PAGES_TOKEN }}
+          enablement: true
+          # Automatically inject basePath in your Next.js configuration file and disable
+          # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
+          #
+          # You may remove this line if you want to manage the configuration yourself.
+          static_site_generator: next
+      - name: Setup Pages (existing site)
+        if: ${{ secrets.PAGES_TOKEN == '' }}
+        uses: actions/configure-pages@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
           # Automatically inject basePath in your Next.js configuration file and disable
           # server side image optimization (https://nextjs.org/docs/api-reference/next/image#unoptimized).
           #


### PR DESCRIPTION
## Summary
- switch to official GitHub Pages deployment
- configure Pages with enablement and upload `out` artifact

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ab0b740c20832a9d9da632b0a0c77c