### PR TITLE
feat: polish event detail page UI

### DIFF
--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -68,22 +68,28 @@ export default async function EventDetailPage({ params }: Props) {
           {new Date(meta.date).toLocaleDateString('ko-KR')}
           {meta.city ? ` · ${meta.city}` : ''}{meta.venue ? ` · ${meta.venue}` : ''}
         </div>
-      {meta.registrationUrl ? (
-        <div className="mt-8">
-          <a href={meta.registrationUrl} target="_blank">접수 링크</a>
+        <div className="actions">
+          {meta.registrationUrl && (
+            <a
+              className="btn btn-primary"
+              href={meta.registrationUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              접수하기
+            </a>
+          )}
+          <a
+            className="btn btn-outline"
+            href={`https://www.google.com/search?q=${encodeURIComponent(meta.title + ' 대회 신청')}`}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            대회 신청 검색
+          </a>
         </div>
-      ) : null}
-      <div className="mt-8">
-        <a
-          href={`https://www.google.com/search?q=${encodeURIComponent(meta.title + ' 대회 신청')}`}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          대회 신청 검색
-        </a>
-      </div>
-      <div className="mt-16" dangerouslySetInnerHTML={{ __html: html }} />
-    </article>
+        <div className="mt-16" dangerouslySetInnerHTML={{ __html: html }} />
+      </article>
     </>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -85,3 +85,35 @@ img { max-width: 100%; height: auto; display: block; }
 .rulebook-tab:hover {
   transform: scale(1.05);
 }
+
+/* buttons */
+.actions {
+  margin-top: 24px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+.btn {
+  display: inline-block;
+  padding: 10px 18px;
+  border-radius: 8px;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+.btn-primary {
+  background: linear-gradient(135deg, #6366f1, #ec4899);
+  color: #fff;
+}
+.btn-outline {
+  border: 2px solid var(--primary);
+  color: var(--primary);
+  background: #fff;
+}
+.btn-outline:hover {
+  background: var(--primary);
+  color: #fff;
+}

--- a/content/events/2025-09-14-seoul-kbjjf-korea-open-24.md
+++ b/content/events/2025-09-14-seoul-kbjjf-korea-open-24.md
@@ -9,4 +9,3 @@ registrationUrl: "https://www.spotlite.me/tournaments/6842"
 sourceUrl: "https://www.spotlite.me/tournaments/6842"
 ---
 
-> 스팟라이트 대회 페이지.


### PR DESCRIPTION
## Summary
- Restyle event detail links with modern buttons to highlight registration actions
- Add global button styles and action group layout
- Remove leftover placeholder text from KBJJF Korea Open event

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afd6e9e0ec832a8d5790cef9f2b907