### PR TITLE
Add security rel to external event link

### DIFF
--- a/app/events/page.tsx
+++ b/app/events/page.tsx
@@ -20,7 +20,13 @@ export default function EventsListPage() {
             <div style={{ marginTop: 8 }}>{e.excerpt}</div>
             {e.registrationUrl ? (
               <div style={{ marginTop: 8 }}>
-                <a href={e.registrationUrl} target="_blank">접수 링크 바로가기</a>
+                <a
+                  href={e.registrationUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  접수 링크 바로가기
+                </a>
               </div>
             ) : null}
           </div>


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to external registration link on events page
- verify other external links already include `rel`

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afeeced4e4832a92a91b8b63de64bc