### PR TITLE
feat: add skip link to main content

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -16,6 +16,18 @@ body {
 }
 a { color: inherit; text-decoration: none; }
 img { max-width: 100%; height: auto; display: block; }
+.skip-link {
+  position: absolute;
+  top: -40px;
+  left: 0;
+  background: var(--primary);
+  color: #fff;
+  padding: 8px 16px;
+  z-index: 100;
+}
+.skip-link:focus {
+  top: 0;
+}
 
 .container { max-width: 960px; margin: 0 auto; padding: 24px 16px; }
 .header { border-bottom: 1px solid var(--border); background: #fff; position: sticky; top: 0; z-index: 10; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="ko">
       <body>
+        <a href="#main" className="skip-link">본문 바로가기</a>
         <header className="header">
           <div className="container">
             <nav className="nav">
@@ -19,7 +20,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             </nav>
           </div>
         </header>
-        <main className="container">{children}</main>
+        <main id="main" className="container">{children}</main>
         <footer className="footer">
           <div className="container">
             <div className="small">© {new Date().getFullYear()} BJJ 대회 정보</div>


### PR DESCRIPTION
## Summary
- add skip link before main content for quicker navigation
- ensure main element has id for skip link target
- style skip link to appear when focused

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68afeeda9308832abcb087fecc06ee68