### PR TITLE
fix: ensure tab ref callback returns void

### DIFF
--- a/app/events/EventsList.tsx
+++ b/app/events/EventsList.tsx
@@ -56,7 +56,9 @@ export default function EventsList({
         {TABS.map(({ key, label }, idx) => (
           <button
             key={key ?? 'all'}
-            ref={el => (tabRefs.current[idx] = el)}
+            ref={el => {
+              tabRefs.current[idx] = el;
+            }}
             role="tab"
             aria-selected={idx === currentIndex}
             tabIndex={idx === currentIndex ? 0 : -1}


### PR DESCRIPTION
## Summary
- fix EventsList tab ref callback to return void rather than the element

## Testing
- `npm run build`
- `npm run lint`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b00a9a793c832aad8126dad0fc7331