### PR TITLE
feat: animate hero and event cards

### DIFF
--- a/app/events/EventsList.tsx
+++ b/app/events/EventsList.tsx
@@ -56,7 +56,9 @@ export default function EventsList({
         {TABS.map(({ key, label }, idx) => (
           <button
             key={key ?? 'all'}
-            ref={el => (tabRefs.current[idx] = el)}
+            ref={el => {
+              tabRefs.current[idx] = el;
+            }}
             role="tab"
             aria-selected={idx === currentIndex}
             tabIndex={idx === currentIndex ? 0 : -1}
@@ -69,8 +71,12 @@ export default function EventsList({
         ))}
       </div>
       <div className="grid">
-        {items.map(e => (
-          <div key={e.slug} className="card">
+        {items.map((e, idx) => (
+          <div
+            key={e.slug}
+            className="card animated-card"
+            style={{ animationDelay: `${idx * 0.1}s` }}
+          >
             <h3 className="card-title">
               <Link href={`/events/${e.slug}/`}>{e.title}</Link>
             </h3>

--- a/app/globals.css
+++ b/app/globals.css
@@ -45,9 +45,12 @@ img { max-width: 100%; height: auto; display: block; }
   padding: 20px;
   background: #fff;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-  transition: box-shadow 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
-.card:hover { box-shadow: 0 4px 8px rgba(0, 0, 0, 0.08); }
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+}
 .badge {
   display: inline-block;
   padding: 2px 8px;
@@ -79,6 +82,68 @@ img { max-width: 100%; height: auto; display: block; }
 .home-intro { margin-bottom: 24px; color: var(--muted); }
 .mt-8 { margin-top: 8px; }
 .mt-16 { margin-top: 16px; }
+
+/* hero section */
+.hero {
+  position: relative;
+  overflow: hidden;
+  border-radius: 12px;
+  padding: 80px 20px;
+  text-align: center;
+  background: linear-gradient(-45deg, #6366f1, #ec4899, #f97316, #23d5ab);
+  background-size: 400% 400%;
+  animation: gradient 15s ease infinite;
+  color: #fff;
+  margin-bottom: 40px;
+}
+.hero-title {
+  animation: fadeSlideDown 0.8s ease both;
+}
+.hero-intro {
+  animation: fadeSlideDown 0.8s ease both;
+  animation-delay: 0.2s;
+}
+
+/* cards appear animation */
+.animated-card {
+  opacity: 0;
+  transform: translateY(20px);
+  animation: fadeInUp 0.6s ease forwards;
+}
+
+@keyframes gradient {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+@keyframes fadeSlideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
 
 /* floating rulebook button */
 .rulebook-tab {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,8 +8,12 @@ export default function Page() {
   const events = getAllEventsMeta();
   return (
     <div>
-      <h1 className="home-title">주짓수 대회 일정</h1>
-      <p className="home-intro small">국내 주짓수 대회를 한 번에 확인하세요.</p>
+      <section className="hero">
+        <h1 className="home-title hero-title">주짓수 대회 일정</h1>
+        <p className="home-intro small hero-intro">
+          국내 주짓수 대회를 한 번에 확인하세요.
+        </p>
+      </section>
       <Suspense>
         <EventsList events={events} />
       </Suspense>


### PR DESCRIPTION
## Summary
- add animated hero section with gradient background
- animate event cards on load with hover lift
- ensure tab ref callback returns void

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b00a9a793c832aad8126dad0fc7331