### PR TITLE
feat: animate hero and event cards

### DIFF
--- a/app/events/EventsList.tsx
+++ b/app/events/EventsList.tsx
@@ -29,6 +29,9 @@ export default function EventsList({
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const filtered = tag ? events.filter(e => e.tags?.includes(tag)) : events;
   const items = filtered;
+  const counts = TABS.map(({ key }) =>
+    key ? events.filter(e => e.tags?.includes(key)).length : events.length,
+  );
 
   const selectTab = (idx: number) => {
     const { key } = TABS[idx];
@@ -56,7 +59,9 @@ export default function EventsList({
         {TABS.map(({ key, label }, idx) => (
           <button
             key={key ?? 'all'}
-            ref={el => (tabRefs.current[idx] = el)}
+            ref={el => {
+              tabRefs.current[idx] = el;
+            }}
             role="tab"
             aria-selected={idx === currentIndex}
             tabIndex={idx === currentIndex ? 0 : -1}
@@ -65,19 +70,46 @@ export default function EventsList({
             onKeyDown={e => handleKeyDown(e, idx)}
           >
             {label}
+            <span className="tab-count">{counts[idx]}</span>
           </button>
         ))}
       </div>
       <div className="grid">
-        {items.map(e => (
-          <div key={e.slug} className="card">
+        {items.map((e, idx) => (
+          <div
+            key={e.slug}
+            className="card animated-card"
+            style={{ animationDelay: `${idx * 0.1}s` }}
+          >
             <h3 className="card-title">
               <Link href={`/events/${e.slug}/`}>{e.title}</Link>
             </h3>
             <div className="card-meta small">
-              {new Date(e.date).toLocaleDateString('ko-KR')}
-              {e.city ? ` · ${e.city}` : ''}
-              {e.venue ? ` · ${e.venue}` : ''}
+              <span className="meta-item">
+                <svg viewBox="0 0 24 24" fill="none" strokeWidth="2" aria-hidden="true">
+                  <path
+                    d="M8 2v4M16 2v4M3 10h18M5 22h14a2 2 0 002-2V6a2 2 0 00-2-2H5a2 2 0 00-2 2v14a2 2 0 002 2z"
+                  />
+                </svg>
+                {new Date(e.date).toLocaleDateString('ko-KR')}
+              </span>
+              {e.city && (
+                <span className="meta-item">
+                  <svg viewBox="0 0 24 24" fill="none" strokeWidth="2" aria-hidden="true">
+                    <path d="M12 21s-6-5.686-6-10a6 6 0 1112 0c0 4.314-6 10-6 10z" />
+                    <circle cx="12" cy="11" r="2" />
+                  </svg>
+                  {e.city}
+                </span>
+              )}
+              {e.venue && (
+                <span className="meta-item">
+                  <svg viewBox="0 0 24 24" fill="none" strokeWidth="2" aria-hidden="true">
+                    <path d="M3 9l9-7 9 7v11a2 2 0 01-2 2h-4v-5H9v5H5a2 2 0 01-2-2z" />
+                  </svg>
+                  {e.venue}
+                </span>
+              )}
             </div>
             <div className="card-excerpt">{e.excerpt}</div>
             <div className="card-tags">

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,6 +1,7 @@
 /* 기본 스타일과 컬러 팔레트 */
 * { box-sizing: border-box; }
 html, body { padding: 0; margin: 0; }
+html { scroll-behavior: smooth; }
 :root {
   --bg: #f9fafb;
   --border: #e5e7eb;
@@ -30,8 +31,16 @@ img { max-width: 100%; height: auto; display: block; }
 }
 
 .container { max-width: 960px; margin: 0 auto; padding: 24px 16px; }
-.header { border-bottom: 1px solid var(--border); background: #fff; position: sticky; top: 0; z-index: 10; }
-.nav { display: flex; gap: 16px; padding: 16px 0; font-weight: 500; }
+.header {
+  border-bottom: 1px solid var(--border);
+  background: rgba(255, 255, 255, 0.8);
+  backdrop-filter: blur(8px);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  animation: slideDown 0.6s ease;
+}
+.nav { display: flex; gap: 16px; padding: 16px 0; font-weight: 500; align-items: center; }
 .logo { font-weight: 600; font-size: 18px; }
 .footer { border-top: 1px solid var(--border); padding: 24px 0; color: var(--muted); font-size: 14px; margin-top: 40px; }
 
@@ -45,9 +54,12 @@ img { max-width: 100%; height: auto; display: block; }
   padding: 20px;
   background: #fff;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-  transition: box-shadow 0.2s ease;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
-.card:hover { box-shadow: 0 4px 8px rgba(0, 0, 0, 0.08); }
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+}
 .badge {
   display: inline-block;
   padding: 2px 8px;
@@ -66,19 +78,103 @@ img { max-width: 100%; height: auto; display: block; }
   border-radius: 999px;
   font-size: 14px;
   background: var(--bg);
-  transition: background 0.2s ease, color 0.2s ease;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease,
+    box-shadow 0.2s ease;
+  display: inline-flex;
+  align-items: center;
 }
-.tab:hover { background: #e5e7eb; }
-.tab.active { background: var(--primary); color: #fff; border-color: var(--primary); }
+.tab:hover {
+  background: #e5e7eb;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+.tab.active {
+  background: var(--primary);
+  color: #fff;
+  border-color: var(--primary);
+}
+
+.tab-count {
+  margin-left: 6px;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--primary);
+  color: #fff;
+  font-size: 12px;
+}
 
 .card-title { margin: 0 0 8px; font-size: 18px; }
-.card-meta { margin-top: 4px; }
+.card-meta { margin-top: 4px; display: flex; flex-wrap: wrap; gap: 8px; }
+.meta-item { display: inline-flex; align-items: center; gap: 4px; }
+.meta-item svg { width: 14px; height: 14px; stroke: currentColor; }
 .card-excerpt { margin-top: 8px; }
 .card-tags { margin-top: 12px; }
 .home-title { font-size: 28px; margin-bottom: 4px; }
 .home-intro { margin-bottom: 24px; color: var(--muted); }
 .mt-8 { margin-top: 8px; }
 .mt-16 { margin-top: 16px; }
+
+/* hero section */
+.hero {
+  position: relative;
+  overflow: hidden;
+  border-radius: 12px;
+  padding: 80px 20px;
+  text-align: center;
+  background: linear-gradient(-45deg, #6366f1, #ec4899, #f97316, #23d5ab);
+  background-size: 400% 400%;
+  animation: gradient 15s ease infinite;
+  color: #fff;
+  margin-bottom: 40px;
+}
+.hero-title {
+  animation: fadeSlideDown 0.8s ease both;
+}
+.hero-intro {
+  animation: fadeSlideDown 0.8s ease both;
+  animation-delay: 0.2s;
+}
+
+/* cards appear animation */
+.animated-card {
+  opacity: 0;
+  transform: translateY(20px);
+  animation: fadeInUp 0.6s ease forwards;
+}
+
+@keyframes gradient {
+  0% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+@keyframes fadeSlideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
 
 /* floating rulebook button */
 .rulebook-tab {
@@ -128,4 +224,15 @@ img { max-width: 100%; height: auto; display: block; }
 .btn-outline:hover {
   background: var(--primary);
   color: #fff;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-100%);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,8 +8,12 @@ export default function Page() {
   const events = getAllEventsMeta();
   return (
     <div>
-      <h1 className="home-title">주짓수 대회 일정</h1>
-      <p className="home-intro small">국내 주짓수 대회를 한 번에 확인하세요.</p>
+      <section className="hero">
+        <h1 className="home-title hero-title">주짓수 대회 일정</h1>
+        <p className="home-intro small hero-intro">
+          국내 주짓수 대회를 한 번에 확인하세요.
+        </p>
+      </section>
       <Suspense>
         <EventsList events={events} />
       </Suspense>


### PR DESCRIPTION
## Summary
- add animated hero section with gradient background
- animate event cards on load with hover lift
- ensure tab ref callback returns void
- add glassy animated header with smooth scrolling
- show event counts and icons for clearer event cards

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b00a9a793c832aad8126dad0fc7331