### PR TITLE
feat: make hero typography responsive

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -131,7 +131,7 @@ img { max-width: 100%; height: auto; display: block; }
   animation: fadeSlideDown 0.8s ease both;
   position: relative;
   z-index: 1;
-  font-size: 48px;
+  font-size: clamp(32px, 5vw, 56px);
   font-weight: 700;
   line-height: 1.2;
   text-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
@@ -142,7 +142,8 @@ img { max-width: 100%; height: auto; display: block; }
   position: relative;
   z-index: 1;
   color: rgba(255, 255, 255, 0.9);
-  font-size: 18px;
+  font-size: clamp(16px, 2.5vw, 24px);
+  line-height: 1.6;
 }
 
 .hero-orb {


### PR DESCRIPTION
## Summary
- make hero section font sizes responsive with CSS `clamp`
- set hero intro line-height for better readability

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1d7454084832abd2db08706c67c99