### PR TITLE
feat: add region filter for events

### DIFF
--- a/app/events/EventsList.tsx
+++ b/app/events/EventsList.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useRef, type KeyboardEvent } from 'react';
+import RegionFilter from './RegionFilter';
 import type { EventMeta } from '@/lib/content';
 
 const TABS = [
@@ -22,20 +23,53 @@ export default function EventsList({
   const searchParams = useSearchParams();
   const router = useRouter();
   const tag = searchParams.get('tag') || undefined;
+  const region = searchParams.get('region') || undefined;
+  const showPast = searchParams.get('past') === '1';
   const currentIndex = Math.max(
     0,
     TABS.findIndex(t => t.key === tag),
   );
   const tabRefs = useRef<(HTMLButtonElement | null)[]>([]);
-  const filtered = tag ? events.filter(e => e.tags?.includes(tag)) : events;
-  const items = filtered;
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const dateFiltered = showPast
+    ? events
+    : events.filter(e => new Date(e.date) >= today);
+
+  const regionFiltered = region
+    ? dateFiltered.filter(e => e.city === region)
+    : dateFiltered;
+
   const counts = TABS.map(({ key }) =>
-    key ? events.filter(e => e.tags?.includes(key)).length : events.length,
+    key
+      ? regionFiltered.filter(e => e.tags?.includes(key)).length
+      : regionFiltered.length,
   );
+
+  const items = tag
+    ? regionFiltered.filter(e => e.tags?.includes(tag))
+    : regionFiltered;
+
+  const togglePast = (checked: boolean) => {
+    const params = new URLSearchParams(Array.from(searchParams.entries()));
+    if (checked) {
+      params.set('past', '1');
+    } else {
+      params.delete('past');
+    }
+    router.push(`${basePath}?${params.toString()}`);
+  };
 
   const selectTab = (idx: number) => {
     const { key } = TABS[idx];
-    router.push(key ? `${basePath}?tag=${key}` : basePath);
+    const params = new URLSearchParams(Array.from(searchParams.entries()));
+    if (key) {
+      params.set('tag', key);
+    } else {
+      params.delete('tag');
+    }
+    router.push(`${basePath}?${params.toString()}`);
   };
 
   const handleKeyDown = (
@@ -55,6 +89,17 @@ export default function EventsList({
 
   return (
     <>
+      <RegionFilter events={dateFiltered} basePath={basePath} />
+      <div className="past-toggle">
+        <label>
+          <input
+            type="checkbox"
+            checked={showPast}
+            onChange={e => togglePast(e.target.checked)}
+          />
+          날짜 지난 시합 일정도 보기
+        </label>
+      </div>
       <div className="tabs" role="tablist">
         {TABS.map(({ key, label }, idx) => (
           <button

--- a/app/events/RegionFilter.tsx
+++ b/app/events/RegionFilter.tsx
@@ -1,0 +1,148 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useMemo, useState, useRef, useEffect } from 'react';
+import type { EventMeta } from '@/lib/content';
+
+export default function RegionFilter({
+  events,
+  basePath = '/',
+}: {
+  events: EventMeta[];
+  basePath?: string;
+}) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const region = searchParams.get('region') || '';
+  const [open, setOpen] = useState(false);
+  const [search, setSearch] = useState('');
+  const [recent, setRecent] = useState<string[]>([]);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const stored = localStorage.getItem('recentRegions');
+    if (stored) setRecent(JSON.parse(stored));
+  }, []);
+
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', handleClick);
+    return () => document.removeEventListener('mousedown', handleClick);
+  }, []);
+
+  const regions = useMemo(() => {
+    const set = new Set<string>();
+    events.forEach(e => {
+      if (e.city) set.add(e.city);
+    });
+    return Array.from(set).sort();
+  }, [events]);
+
+  const filtered = useMemo(
+    () => regions.filter(r => r.includes(search)),
+    [regions, search],
+  );
+
+  const updateRegion = (value: string) => {
+    const params = new URLSearchParams(Array.from(searchParams.entries()));
+    if (value) {
+      params.set('region', value);
+    } else {
+      params.delete('region');
+    }
+    const query = params.toString();
+    router.push(`${basePath}${query ? `?${query}` : ''}`);
+  };
+
+  const selectRegion = (value: string) => {
+    updateRegion(value);
+    setOpen(false);
+    if (value) {
+      setRecent(prev => {
+        const next = [value, ...prev.filter(r => r !== value)].slice(0, 5);
+        localStorage.setItem('recentRegions', JSON.stringify(next));
+        return next;
+      });
+    }
+  };
+
+  return (
+    <div className="region-filter" ref={ref}>
+      <button
+        type="button"
+        className="region-button"
+        onClick={() => setOpen(o => !o)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        <svg viewBox="0 0 24 24" fill="none" strokeWidth="2" aria-hidden="true">
+          <path d="M12 21s-6-5.686-6-10a6 6 0 1112 0c0 4.314-6 10-6 10z" />
+          <circle cx="12" cy="11" r="2" />
+        </svg>
+        <span>{region || '지역 선택'}</span>
+      </button>
+      {open && (
+        <div className="region-dropdown" role="listbox">
+          <input
+            type="text"
+            className="region-search"
+            placeholder="지역 검색..."
+            value={search}
+            onChange={e => setSearch(e.target.value)}
+          />
+          {recent.length > 0 && (
+            <>
+              <div className="dropdown-section-title">최근 선택</div>
+              <div className="region-options">
+                {recent.map(r => (
+                  <button
+                    key={`recent-${r}`}
+                    className="region-option"
+                    onClick={() => selectRegion(r)}
+                    role="option"
+                    aria-selected={region === r}
+                  >
+                    {r}
+                  </button>
+                ))}
+              </div>
+            </>
+          )}
+          <div className="dropdown-section-title">전체 지역</div>
+          <div className="region-options">
+            {filtered.map(r => (
+              <button
+                key={r}
+                className="region-option"
+                onClick={() => selectRegion(r)}
+                role="option"
+                aria-selected={region === r}
+              >
+                {r}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+      {region && (
+        <div className="selected-region">
+          <span className="badge">
+            {region}
+            <button
+              type="button"
+              aria-label="지역 제거"
+              onClick={() => selectRegion('')}
+            >
+              ×
+            </button>
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -259,6 +259,90 @@ img { max-width: 100%; height: auto; display: block; }
   flex-wrap: wrap;
   gap: 12px;
 }
+
+/* region filter */
+.region-filter {
+  position: relative;
+  margin-bottom: 16px;
+}
+.region-button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #fff;
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+.region-button:hover {
+  background: #f3f4f6;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
+}
+.region-button svg {
+  width: 16px;
+  height: 16px;
+  stroke: currentColor;
+}
+.region-dropdown {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 20;
+  width: 260px;
+  padding: 12px;
+  background: #fff;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
+  animation: fadeSlideDown 0.2s ease;
+}
+.region-search {
+  width: 100%;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  margin-bottom: 8px;
+}
+.dropdown-section-title {
+  font-size: 12px;
+  color: var(--muted);
+  margin: 8px 0 4px;
+}
+.region-options {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+  gap: 8px;
+}
+.region-option {
+  padding: 6px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  cursor: pointer;
+  transition: background 0.2s ease;
+  font-size: 14px;
+}
+.region-option:hover {
+  background: #e5e7eb;
+}
+.selected-region {
+  margin-top: 8px;
+}
+.selected-region .badge button {
+  margin-left: 4px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+.past-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 16px 0;
+  font-size: 14px;
+}
 .btn {
   display: inline-block;
   padding: 10px 18px;


### PR DESCRIPTION
## Summary
- integrate dropdown-based region filter into events list
- add client region filter component
- sync tag tab counts with selected region
- redesign region filter with search, recent selections, and polished styles
- default to upcoming events with option to show past competitions

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1e7462c20832a9e5c5efb1ab28c95