### PR TITLE
fix: ensure clean sitemap for search console

### DIFF
--- a/.nojekyll
+++ b/.nojekyll
@@ -1,0 +1,1 @@
+Disable Jekyll

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,12 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-  <url>
-    <loc>https://teamhyeok.github.io/team-jiujitsu/</loc>
-  </url>
-  <url>
-    <loc>https://teamhyeok.github.io/team-jiujitsu/events/</loc>
-  </url>
-  <url>
-    <loc>https://teamhyeok.github.io/team-jiujitsu/rules/</loc>
-  </url>
+  <url><loc>https://teamhyeok.github.io/team-jiujitsu/</loc></url>
+  <url><loc>https://teamhyeok.github.io/team-jiujitsu/events/</loc></url>
+  <url><loc>https://teamhyeok.github.io/team-jiujitsu/rules/</loc></url>
 </urlset>


### PR DESCRIPTION
## Summary
- clean sitemap.xml to contain only valid sitemap tags
- disable Jekyll processing so the sitemap remains static

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `curl -I https://teamhyeok.github.io/team-jiujitsu/sitemap.xml`


------
https://chatgpt.com/codex/tasks/task_e_68b2d213a5b4832a98a8466395d0c0f0