### PR TITLE
feat: enhance region filter keyboard support

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -324,6 +324,10 @@ img { max-width: 100%; height: auto; display: block; }
   transition: background 0.2s ease;
   font-size: 14px;
 }
+.region-option:focus {
+  outline: 2px solid var(--primary);
+  outline-offset: 2px;
+}
 .region-option:hover {
   background: #e5e7eb;
 }


### PR DESCRIPTION
## Summary
- make region search case-insensitive
- close dropdown on Escape and support arrow/enter navigation
- add visible focus style for region options

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b443d70f2c832a81d2b9451e253449