### PR TITLE
feat: add events list skeleton

### DIFF
--- a/app/events/EventsListSkeleton.tsx
+++ b/app/events/EventsListSkeleton.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+export default function EventsListSkeleton() {
+  return (
+    <div className="grid">
+      {Array.from({ length: 4 }).map((_, idx) => (
+        <div key={idx} className="card">
+          <div
+            className="skeleton"
+            style={{ height: 20, width: '60%', marginBottom: 8 }}
+          />
+          <div
+            className="skeleton"
+            style={{ height: 14, width: '80%', marginBottom: 6 }}
+          />
+          <div
+            className="skeleton"
+            style={{ height: 14, width: '50%', marginBottom: 16 }}
+          />
+          <div style={{ display: 'flex', gap: 4 }}>
+            {Array.from({ length: 3 }).map((__, tagIdx) => (
+              <span
+                key={tagIdx}
+                className="skeleton"
+                style={{ height: 20, width: 40, borderRadius: 4 }}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -401,3 +401,13 @@ img { max-width: 100%; height: auto; display: block; }
   background: var(--primary);
 }
 
+@keyframes pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.skeleton {
+  background: var(--border);
+  border-radius: 4px;
+  animation: pulse 1.5s ease-in-out infinite;
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 import Link from 'next/link';
 import { getAllEventsMeta } from '@/lib/content';
 import EventsList from './events/EventsList';
+import EventsListSkeleton from './events/EventsListSkeleton';
 
 export const metadata = { title: '대회 목록' };
 
@@ -24,7 +25,7 @@ export default function Page() {
         </div>
       </section>
       <section id="events">
-        <Suspense>
+        <Suspense fallback={<EventsListSkeleton />}>
           <EventsList events={events} />
         </Suspense>
       </section>


### PR DESCRIPTION
## Summary
- add skeleton UI for event cards
- wire skeleton as Suspense fallback on events page
- animate skeleton placeholders

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Type error in app/events/RegionFilter.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68b445469c60832aba068c2e7767a3bb