### PR TITLE
Display event cover images

### DIFF
--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -65,6 +65,14 @@ export default async function EventDetailPage({ params }: Props) {
         dangerouslySetInnerHTML={{ __html: JSON.stringify(eventJsonLd) }}
       />
       <article>
+        {meta.cover && (
+          <img
+            className="event-cover"
+            src={meta.cover}
+            alt={meta.title}
+            loading="lazy"
+          />
+        )}
         <h1>{meta.title}</h1>
         <div className="small">
           {new Date(meta.date).toLocaleDateString('ko-KR')}

--- a/app/globals.css
+++ b/app/globals.css
@@ -113,6 +113,12 @@ img { max-width: 100%; height: auto; display: block; }
 .mt-8 { margin-top: 8px; }
 .mt-16 { margin-top: 16px; }
 
+.event-cover {
+  width: 100%;
+  border-radius: 12px;
+  margin-bottom: 16px;
+}
+
 /* hero section */
 .hero {
   position: relative;


### PR DESCRIPTION
## Summary
- show cover image on event detail page when available
- style event cover with full width and rounded corners

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b44675b174832ab8eb2db6854384fa