### PR TITLE
Wrap event cards with link container

### DIFF
--- a/app/events/EventsList.tsx
+++ b/app/events/EventsList.tsx
@@ -125,14 +125,13 @@ export default function EventsList({
       </div>
       <div className="grid">
         {items.map((e, idx) => (
-          <div
+          <Link
             key={e.slug}
+            href={`/events/${e.slug}/`}
             className="card animated-card"
             style={{ animationDelay: `${idx * 0.1}s` }}
           >
-            <h3 className="card-title">
-              <Link href={`/events/${e.slug}/`}>{e.title}</Link>
-            </h3>
+            <h3 className="card-title">{e.title}</h3>
             <div className="card-meta small">
               <span className="meta-item">
                 <svg viewBox="0 0 24 24" fill="none" strokeWidth="2" aria-hidden="true">
@@ -168,7 +167,7 @@ export default function EventsList({
                 </span>
               ))}
             </div>
-          </div>
+          </Link>
         ))}
       </div>
     </>


### PR DESCRIPTION
## Summary
- Wrap each event card in a `Link` so the entire card is clickable
- Move hover/animation classes and inline styles onto the `Link`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b44672cdc4832a9e594e86301cbd47