### PR TITLE
feat: add news pages

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,6 +25,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               <Link href="/" className="logo">
                 BJJ 대회 캘린더
               </Link>
+              <Link href="/news">뉴스</Link>
               <CursorToggle />
             </nav>
           </div>

--- a/app/news/[slug]/page.tsx
+++ b/app/news/[slug]/page.tsx
@@ -1,0 +1,58 @@
+import { getAllNewsMeta, getNewsHtmlBySlug } from '@/lib/content';
+import { notFound } from 'next/navigation';
+import type { Metadata } from 'next';
+import DOMPurify from 'isomorphic-dompurify';
+
+export const dynamicParams = false;
+
+export function generateStaticParams() {
+  return getAllNewsMeta().map(n => ({ slug: n.slug }));
+}
+
+type Props = { params: Promise<{ slug: string }> };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const { slug } = await params;
+  const meta = getAllNewsMeta().find(n => n.slug === slug);
+  if (!meta) return { title: '뉴스' };
+  return {
+    title: meta.title,
+    description: meta.excerpt || `${meta.title} 관련 소식`,
+    keywords: meta.tags || [],
+  };
+}
+
+export default async function NewsDetailPage({ params }: Props) {
+  const { slug } = await params;
+  const meta = getAllNewsMeta().find(n => n.slug === slug);
+  if (!meta) notFound();
+
+  const rawHtml = await getNewsHtmlBySlug(slug);
+  const html = DOMPurify.sanitize(rawHtml);
+
+  return (
+    <article>
+      {meta.cover && (
+        <img
+          className="event-cover"
+          src={meta.cover}
+          alt={meta.title}
+          loading="lazy"
+        />
+      )}
+      <h1>{meta.title}</h1>
+      <div className="small">
+        {new Date(meta.date).toLocaleDateString('ko-KR')}
+        {meta.sourceName ? ` · ${meta.sourceName}` : ''}
+      </div>
+      {meta.sourceUrl && (
+        <div className="mt-8">
+          <a href={meta.sourceUrl} target="_blank" rel="noopener noreferrer">
+            원문 보기
+          </a>
+        </div>
+      )}
+      <div className="mt-16" dangerouslySetInnerHTML={{ __html: html }} />
+    </article>
+  );
+}

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link';
+import { getAllNewsMeta } from '@/lib/content';
+
+export const metadata = { title: '뉴스 목록' };
+
+export default function NewsListPage() {
+  const items = getAllNewsMeta();
+  return (
+    <div>
+      <h1>뉴스</h1>
+      <div className="grid">
+        {items.map(n => (
+          <div key={n.slug} className="card">
+            <h3 style={{ margin: '8px 0' }}>
+              <Link href={`/news/${n.slug}/`}>{n.title}</Link>
+            </h3>
+            <div className="small">
+              {new Date(n.date).toLocaleDateString('ko-KR')}
+              {n.sourceName ? ` · ${n.sourceName}` : ''}
+            </div>
+            <div style={{ marginTop: 8 }}>{n.excerpt}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add news list page using `getAllNewsMeta`
- add news detail page with static params and metadata
- link to news in main navigation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4639b9ec4832a9192b624e17d6e1a