### PR TITLE
feat: add calendar integration for events

### DIFF
--- a/app/events/[slug]/page.tsx
+++ b/app/events/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { getAllEventsMeta, getEventHtmlBySlug } from '@/lib/content';
 import { notFound } from 'next/navigation';
 import type { Metadata } from 'next';
 import DOMPurify from 'isomorphic-dompurify';
+import AddToCalendar from '@/components/AddToCalendar';
 
 export const dynamicParams = false;
 
@@ -89,6 +90,7 @@ export default async function EventDetailPage({ params }: Props) {
               접수하기
             </a>
           )}
+          <AddToCalendar meta={meta} />
           <a
             className="btn btn-outline"
             href={`https://www.google.com/search?q=${encodeURIComponent(meta.title + ' 대회 신청')}`}

--- a/components/AddToCalendar.tsx
+++ b/components/AddToCalendar.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import type { EventMeta } from '@/lib/content';
+import { eventToICS } from '@/lib/ics';
+
+type Props = {
+  meta: EventMeta;
+};
+
+export default function AddToCalendar({ meta }: Props) {
+  const download = () => {
+    const ics = eventToICS(meta);
+    const blob = new Blob([ics], { type: 'text/calendar' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `${meta.slug}.ics`;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const start = new Date(meta.date);
+  const end = new Date(start);
+  end.setDate(start.getDate() + 1);
+  const fmt = (d: Date) => d.toISOString().slice(0, 10).replace(/-/g, '');
+  const dates = `${fmt(start)}/${fmt(end)}`;
+  const details = encodeURIComponent(meta.excerpt || '');
+  const location = encodeURIComponent(
+    [meta.venue, meta.city].filter(Boolean).join(', ')
+  );
+  const gcalUrl = `https://calendar.google.com/calendar/render?action=TEMPLATE&text=${encodeURIComponent(
+    meta.title,
+  )}&dates=${dates}&details=${details}&location=${location}`;
+
+  return (
+    <>
+      <button type="button" className="btn btn-outline" onClick={download}>
+        캘린더에 추가
+      </button>
+      <a
+        className="btn btn-outline"
+        href={gcalUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        구글 캘린더
+      </a>
+    </>
+  );
+}

--- a/lib/ics.ts
+++ b/lib/ics.ts
@@ -1,0 +1,41 @@
+import type { EventMeta } from './content';
+
+function formatDate(d: Date) {
+  return d.toISOString().slice(0, 10).replace(/-/g, '');
+}
+
+function formatDateTime(d: Date) {
+  return d.toISOString().replace(/[-:]/g, '').split('.')[0] + 'Z';
+}
+
+function escape(text: string) {
+  return text.replace(/\\n/g, '\\n').replace(/,/g, '\\,').replace(/;/g, '\\;');
+}
+
+export function eventToICS(meta: EventMeta): string {
+  const start = new Date(meta.date);
+  const end = new Date(start);
+  end.setDate(start.getDate() + 1);
+
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//team-jiujitsu//EN',
+    'CALSCALE:GREGORIAN',
+    'BEGIN:VEVENT',
+    `UID:${meta.slug}@team-jiujitsu`,
+    `DTSTAMP:${formatDateTime(new Date())}`,
+    `DTSTART;VALUE=DATE:${formatDate(start)}`,
+    `DTEND;VALUE=DATE:${formatDate(end)}`,
+    `SUMMARY:${escape(meta.title)}`,
+    meta.excerpt ? `DESCRIPTION:${escape(meta.excerpt)}` : '',
+    meta.city || meta.venue
+      ? `LOCATION:${escape([meta.venue, meta.city].filter(Boolean).join(', '))}`
+      : '',
+    meta.registrationUrl ? `URL:${meta.registrationUrl}` : '',
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ];
+
+  return lines.filter(Boolean).join('\r\n');
+}


### PR DESCRIPTION
## Summary
- generate .ics files from event metadata
- let users add events to their own calendars and open Google Calendar with prefilled details

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b463a35b3c832aa11a6d4746fc92f9