### PR TITLE
Improve dark mode styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -8,6 +8,9 @@ html { scroll-behavior: smooth; }
   --text: #111;
   --muted: #6b7280;
   --primary: #111;
+  --surface: #fff;
+  --hover: #e5e7eb;
+  --header-bg: rgba(255, 255, 255, 0.8);
 }
 [data-theme="dark"] {
   --bg: #111827;
@@ -15,6 +18,9 @@ html { scroll-behavior: smooth; }
   --text: #f9fafb;
   --muted: #9ca3af;
   --primary: #fff;
+  --surface: #1f2937;
+  --hover: #374151;
+  --header-bg: rgba(17, 24, 39, 0.8);
 }
 body {
   color: var(--text);
@@ -39,7 +45,7 @@ img { max-width: 100%; height: auto; display: block; }
 .container { max-width: 960px; margin: 0 auto; padding: 24px 16px; }
 .header {
   border-bottom: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.8);
+  background: var(--header-bg);
   backdrop-filter: blur(8px);
   position: sticky;
   top: 0;
@@ -61,7 +67,7 @@ img { max-width: 100%; height: auto; display: block; }
 }
 .theme-toggle:hover,
 .cursor-toggle:hover {
-  background: #e5e7eb;
+  background: var(--hover);
 }
 .footer { border-top: 1px solid var(--border); padding: 24px 0; color: var(--muted); font-size: 14px; margin-top: 40px; }
 
@@ -73,7 +79,7 @@ img { max-width: 100%; height: auto; display: block; }
   border: 1px solid var(--border);
   border-radius: 12px;
   padding: 20px;
-  background: #fff;
+  background: var(--surface);
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
@@ -88,7 +94,7 @@ img { max-width: 100%; height: auto; display: block; }
   background: var(--bg);
   border-radius: 4px;
   margin-right: 4px;
-  color: #444;
+  color: var(--text);
 }
 .small { color: var(--muted); font-size: 14px; }
 
@@ -105,13 +111,13 @@ img { max-width: 100%; height: auto; display: block; }
   align-items: center;
 }
 .tab:hover {
-  background: #e5e7eb;
+  background: var(--hover);
   transform: translateY(-2px);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 .tab.active {
   background: var(--primary);
-  color: #fff;
+  color: var(--bg);
   border-color: var(--primary);
 }
 
@@ -120,7 +126,7 @@ img { max-width: 100%; height: auto; display: block; }
   padding: 2px 6px;
   border-radius: 999px;
   background: var(--primary);
-  color: #fff;
+  color: var(--bg);
   font-size: 12px;
 }
 
@@ -285,6 +291,8 @@ img { max-width: 100%; height: auto; display: block; }
   border: 1px solid var(--border);
   border-radius: 6px;
   margin-bottom: 16px;
+  background: var(--surface);
+  color: var(--text);
 }
 
 /* region filter */
@@ -299,12 +307,12 @@ img { max-width: 100%; height: auto; display: block; }
   padding: 8px 12px;
   border: 1px solid var(--border);
   border-radius: 8px;
-  background: #fff;
+  background: var(--surface);
   cursor: pointer;
   transition: background 0.2s ease, box-shadow 0.2s ease;
 }
 .region-button:hover {
-  background: #f3f4f6;
+  background: var(--hover);
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.05);
 }
 .region-button svg {
@@ -319,7 +327,7 @@ img { max-width: 100%; height: auto; display: block; }
   z-index: 20;
   width: 260px;
   padding: 12px;
-  background: #fff;
+  background: var(--surface);
   border: 1px solid var(--border);
   border-radius: 8px;
   box-shadow: 0 8px 16px rgba(0, 0, 0, 0.1);
@@ -330,6 +338,8 @@ img { max-width: 100%; height: auto; display: block; }
   border: 1px solid var(--border);
   border-radius: 6px;
   margin-bottom: 8px;
+  background: var(--surface);
+  color: var(--text);
 }
 .dropdown-section-title {
   font-size: 12px;
@@ -355,7 +365,7 @@ img { max-width: 100%; height: auto; display: block; }
   outline-offset: 2px;
 }
 .region-option:hover {
-  background: #e5e7eb;
+  background: var(--hover);
 }
 .selected-region {
   margin-top: 8px;
@@ -391,7 +401,7 @@ img { max-width: 100%; height: auto; display: block; }
 .btn-outline {
   border: 2px solid var(--primary);
   color: var(--primary);
-  background: #fff;
+  background: var(--surface);
 }
 .btn-outline:hover {
   background: var(--primary);


### PR DESCRIPTION
## Summary
- add CSS variables for surface, hover, and header backgrounds
- use theme variables for header, cards, tabs, inputs, and region filters
- ensure active tabs and badges contrast correctly in dark mode

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b46b76dc50832a8385c1d0f839466c